### PR TITLE
some small tidyups

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,45 +1,20 @@
-name: CI
-
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
-
+name: Tests
+on: [push, pull_request]
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        include:
-          - python-version: 2.7
-            toxenv: py27
-          - python-version: 3.5
-            toxenv: py35
-          - python-version: 3.6
-            toxenv: py36
-          - python-version: 3.7
-            toxenv: py37
-          - python-version: 3.8
-            toxenv: py38
-          - python-version: 3.9
-            toxenv: py39
-          - python-version: pypy-2.7
-            toxenv: pypy
-          - python-version: pypy-3.7
-            toxenv: pypy3
-
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, '3.10', 3.11-dev, 'pypy-2.7', 'pypy-3.6']
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install tox
-        run: pip install tox
-      - name: Tox
-        run: tox
-        env:
-          TOXENV: ${{ matrix.toxenv }}
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: run tests
+      run: |
+        pip install --upgrade pip
+        pip install --upgrade setuptools setuptools_scm pep517
+        pip install .[tests]
+        pytest -vv

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,20 +1,45 @@
-name: Tests
-on: [push, pull_request]
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, '3.10', 3.11-dev, 'pypy-2.7', 'pypy-3.6']
+        include:
+          - python-version: 2.7
+            toxenv: py27
+          - python-version: 3.5
+            toxenv: py35
+          - python-version: 3.6
+            toxenv: py36
+          - python-version: 3.7
+            toxenv: py37
+          - python-version: 3.8
+            toxenv: py38
+          - python-version: 3.9
+            toxenv: py39
+          - python-version: pypy-2.7
+            toxenv: pypy
+          - python-version: pypy-3.7
+            toxenv: pypy3
+
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: run tests
-      run: |
-        pip install --upgrade pip
-        pip install --upgrade setuptools setuptools_scm pep517
-        pip install .[tests]
-        pytest -vv
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install tox
+        run: pip install tox
+      - name: Tox
+        run: tox
+        env:
+          TOXENV: ${{ matrix.toxenv }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,7 +2,7 @@ name: Tests
 on: [push, pull_request]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, '3.10', 3.11-dev, 'pypy-2.7', 'pypy-3.6']

--- a/snoop/__init__.py
+++ b/snoop/__init__.py
@@ -13,10 +13,11 @@ changed in the decorated function.
 For more information, see https://github.com/alexmojaki/snoop
 '''
 
-from .configuration import install, Config
-from .variables import Attrs, Exploding, Indices, Keys
 import collections
 import sys
+
+from .configuration import Config, install
+from .variables import Attrs, Exploding, Indices, Keys
 
 __VersionInfo = collections.namedtuple('VersionInfo',
                                        ('major', 'minor', 'micro'))

--- a/snoop/configuration.py
+++ b/snoop/configuration.py
@@ -11,7 +11,9 @@ import snoop as package
 from snoop.formatting import DefaultFormatter
 from snoop.pp_module import PP
 from snoop.tracer import Spy, Tracer
-from snoop.utils import builtins as builtins_module, is_pathlike, shitcode, ensure_tuple, QuerySet,  Set, Mapping, Sequence
+from snoop.utils import Mapping, QuerySet, Sequence, Set
+from snoop.utils import builtins as builtins_module
+from snoop.utils import ensure_tuple, is_pathlike, shitcode
 
 try:
     # Enable ANSI escape codes in Windows 10
@@ -42,23 +44,23 @@ def install(
 ):
     """
     Configure output, enable or disable, and add names to builtins. Parameters:
-    
+
     - builtins: set to False to not add any names to builtins,
         so importing will still be required.
-    - snoop, pp, and spy: set to other strings 
+    - snoop, pp, and spy: set to other strings
         to choose the names of these functions in builtins
     - `out`: determines the output destination. By default this is stderr. You can also pass:
         - A string or a `Path` object to write to a file at that location. By default this always will append to the file. Pass `overwrite=True` to clear the file initially.
         - Anything with a `write` method, e.g. `sys.stdout` or a file object.
         - Any callable with a single string argument, e.g. `logger.info`.
     - `color`: determines whether the output includes escape characters to display colored text in the console. If you see weird characters in your output, your console doesn't support colors, so pass `color=False`.
-        - Code is syntax highlighted using [Pygments](http://pygments.org/), and this argument is passed as the style. You can choose a different color scheme by passing a string naming a style (see [this gallery](https://help.farbox.com/pygments.html)) or a style class. The default style is monokai.   
+        - Code is syntax highlighted using [Pygments](http://pygments.org/), and this argument is passed as the style. You can choose a different color scheme by passing a string naming a style (see [this gallery](https://help.farbox.com/pygments.html)) or a style class. The default style is monokai.
         - By default this parameter is set to `out.isatty()`, which is usually true for stdout and stderr but will be false if they are redirected or piped. Pass `True` or a style if you want to force coloring.
         - To see colors in the PyCharm Run window, edit the Run Configuration and tick "Emulate terminal in output console".
     - `prefix`: Pass a string to start all snoop lines with that string so you can grep for them easily.
     - `columns`: This specifies the columns at the start of each output line. You can pass a string with the names of built in columns separated by spaces or commas. These are the available columns:
         - `time`: The current time. This is the only column by default.
-        - `thread`: The name of the current thread.  
+        - `thread`: The name of the current thread.
         - `thread_ident`: The [identifier](https://docs.python.org/3/library/threading.html#threading.Thread.ident) of the current thread, in case thread names are not unique.
         - `file`: The filename (not the full path) of the current function.
         - `full_file`: The full path to the file (also shown anyway when the function is called).
@@ -68,7 +70,7 @@ def install(
         If you want a custom column, please open an issue to tell me what you're interested in! In the meantime, you can pass a list, where the elements are either strings or callables. The callables should take one argument, which will be an `Event` object. It has attributes `frame`, `event`, and `arg`, as specified in [`sys.settrace()`](https://docs.python.org/3/library/sys.html#sys.settrace), and other attributes which may change.
     - `pformat`: set the pretty formatting function `pp` uses. Default is to use the first of `prettyprinter.pformat`, `pprintpp.pformat` and `pprint.pformat` that can be imported.
     """
-    
+
     if builtins:
         setattr(builtins_module, snoop, package.snoop)
         setattr(builtins_module, pp, package.pp)
@@ -93,10 +95,10 @@ def install(
 class Config(object):
     """"
     If you need more control than the global `install` function, e.g. if you want to write to several different files in one process, you can create a `Config` object, e.g: `config = snoop.Config(out=filename)`. Then `config.snoop`, `config.pp` and `config.spy` will use that configuration rather than the global one.
-    
+
     The arguments are the same as the arguments of `install()` relating to output configuration and `enabled`.
     """
-    
+
     def __init__(
             self,
             out=None,

--- a/snoop/formatting.py
+++ b/snoop/formatting.py
@@ -1,5 +1,4 @@
 import ast
-import opcode
 import threading
 import traceback
 from collections import defaultdict
@@ -7,6 +6,7 @@ from datetime import datetime
 from textwrap import dedent
 
 import executing
+import opcode
 import six
 from pygments import highlight
 from pygments.formatters.terminal256 import Terminal256Formatter
@@ -14,9 +14,9 @@ from pygments.lexers.python import Python3Lexer
 from pygments.styles.monokai import MonokaiStyle
 from six import PY3
 
-from snoop.utils import ensure_tuple, short_filename, my_cheap_repr, \
-    NO_ASTTOKENS, optional_numeric_label, try_statement, FormattedValue, ArgDefaultDict, lru_cache
-
+from snoop.utils import (NO_ASTTOKENS, ArgDefaultDict, FormattedValue,
+                         ensure_tuple, lru_cache, my_cheap_repr,
+                         optional_numeric_label, short_filename, try_statement)
 
 try:
     from pygments.lexers.python import Python2Lexer
@@ -61,7 +61,7 @@ class Source(executing.Source):
 
     def get_text_with_indentation(self, node):
         result = self.asttokens().get_text(node)
-        
+
         if not result:
             if isinstance(node, FormattedValue):
                 fvals = [
@@ -76,7 +76,7 @@ class Source(executing.Source):
                 )
             else:
                 return "<unknown>"
-        
+
         if '\n' in result:
             result = ' ' * node.first_token.start[1] + result
             result = dedent(result)
@@ -380,7 +380,7 @@ class DefaultFormatter(object):
             decorator = getattr(ex, "decorator", None)
             node = decorator or ex.node
             assert node
-            
+
             description = {
                 ast.Call: 'calling',
                 ast.Subscript: 'subscripting',
@@ -438,7 +438,7 @@ class DefaultFormatter(object):
 
     def format_log(self, event):
         return self.format_lines(event, ['LOG:'])
-    
+
     def format_log_value(self, event, source, value, depth):
         prefix = u'....{} '.format(depth * 4 * '.')
         plain_source_lines = indented_lines(prefix, source)

--- a/snoop/ipython.py
+++ b/snoop/ipython.py
@@ -1,7 +1,8 @@
 import ast
 
-from snoop import snoop
 from IPython.core.magic import Magics, cell_magic, magics_class
+
+from snoop import snoop
 
 
 @magics_class
@@ -16,14 +17,14 @@ class SnoopMagics(Magics):
         for node in ast.walk(ast.parse(cell)):
             if isinstance(node, ast.Name):
                 name = node.id
-                
+
                 if isinstance(
                         self.shell.user_global_ns.get(name),
-                        type(ast),  
+                        type(ast),
                 ):
                     # hide modules
                     continue
-                    
+
                 tracer.variable_whitelist.add(name)
 
         tracer.target_codes.add(code)

--- a/snoop/pp_module.py
+++ b/snoop/pp_module.py
@@ -6,11 +6,12 @@ from copy import deepcopy
 from threading import current_thread
 from uuid import uuid4
 
-from executing import only, future_flags
+from executing import future_flags, only
 
 from snoop.formatting import Event, Source
 from snoop.tracer import FrameInfo
-from snoop.utils import NO_ASTTOKENS, optional_numeric_label, builtins, FormattedValue, pp_name_prefix
+from snoop.utils import (NO_ASTTOKENS, FormattedValue, builtins,
+                         optional_numeric_label, pp_name_prefix)
 
 
 class PP(object):
@@ -80,7 +81,7 @@ class PPEvent(object):
         formatted = self.config.formatter.format_log_value(
             self.event, source, value_string, depth)
         self.config.write(formatted)
-    
+
     def write_node(self, node, value, depth=0):
         source = self.event.source.get_text_with_indentation(node)
         self.write(source, value, depth=depth)
@@ -99,7 +100,7 @@ class PPEvent(object):
     def deep_pp(self, call_arg, frame):
         stack = []
         thread = current_thread()
-        
+
         def before_expr(tree_index):
             node = self.event.source.nodes[tree_index]
             if thread == current_thread():
@@ -210,7 +211,7 @@ class NodeVisitor(ast.NodeTransformer):
         )
 
         ast.copy_location(before_marker, node)
-        
+
         if isinstance(node, FormattedValue):
             arg = node
         else:

--- a/snoop/tracer.py
+++ b/snoop/tracer.py
@@ -10,11 +10,14 @@ import six
 # noinspection PyUnresolvedReferences
 from cheap_repr import cheap_repr, find_repr_function, try_register_repr
 
-from snoop.utils import my_cheap_repr, ArgDefaultDict, iscoroutinefunction, \
-    truncate_list, ensure_tuple, is_comprehension_frame, no_args_decorator, pp_name_prefix, NO_BIRDSEYE, \
-    _register_cheap_reprs, PY34
+from snoop.utils import (NO_BIRDSEYE, PY34, ArgDefaultDict,
+                         _register_cheap_reprs, ensure_tuple,
+                         is_comprehension_frame, iscoroutinefunction,
+                         my_cheap_repr, no_args_decorator, pp_name_prefix,
+                         truncate_list)
+
 from .formatting import Event, Source
-from .variables import CommonVariable, Exploding, BaseVariable
+from .variables import BaseVariable, CommonVariable, Exploding
 
 find_repr_function(six.text_type).maxparts = 100
 find_repr_function(six.binary_type).maxparts = 100
@@ -221,7 +224,7 @@ class Tracer(object):
 
     def _is_internal_frame(self, frame):
         return frame.f_code.co_filename.startswith(internal_directories)
-    
+
     def _is_traced_frame(self, frame):
         return frame.f_code in self.target_codes or frame in self.target_frames
 

--- a/snoop/utils.py
+++ b/snoop/utils.py
@@ -139,7 +139,7 @@ except ImportError:
 
 try:
     FormattedValue = ast.FormattedValue
-except:
+except Exception:
     class FormattedValue(object):
         pass
 
@@ -156,10 +156,10 @@ except ImportError:
 
 if six.PY2:
     # noinspection PyUnresolvedReferences
-    from collections import Sequence, Mapping, Set
+    from collections import Mapping, Sequence, Set
 else:
     # noinspection PyUnresolvedReferences,PyCompatibility
-    from collections.abc import Sequence, Mapping, Set
+    from collections.abc import Mapping, Sequence, Set
 
 
 class DirectRepr(str):

--- a/snoop/variables.py
+++ b/snoop/variables.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 
 import six
 
-from snoop.utils import with_needed_parentheses, my_cheap_repr, ensure_tuple
+from snoop.utils import ensure_tuple, my_cheap_repr, with_needed_parentheses
 
 if six.PY2:
     from collections import Mapping, Sequence

--- a/tests/samples/enabled.py
+++ b/tests/samples/enabled.py
@@ -1,6 +1,6 @@
-from snoop.configuration import Config
-
 from birdseye import eye
+
+from snoop.configuration import Config
 
 config = Config(enabled=False)
 

--- a/tests/samples/exception.py
+++ b/tests/samples/exception.py
@@ -40,7 +40,7 @@ def main():
         pass
 
     x = [[[2]]]
-    
+
     try:
         str(x[1][0][0])
     except:

--- a/tests/samples/multiline.py
+++ b/tests/samples/multiline.py
@@ -60,7 +60,7 @@ def main():
             )
         ]:
             pass
-        
+
     return x
 
 

--- a/tests/samples/with_block.py
+++ b/tests/samples/with_block.py
@@ -51,7 +51,7 @@ def gen():
 def main():
     foo(2)
     list(gen())
-    
-    
+
+
 if __name__ == '__main__':
     main()

--- a/tests/test_snoop.py
+++ b/tests/test_snoop.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+
 import io
 import os
 import re
@@ -12,7 +13,7 @@ import pytest
 import six
 from cheap_repr import cheap_repr, register_repr
 from cheap_repr.utils import safe_qualname
-from littleutils import file_to_string, string_to_file, group_by_key_func
+from littleutils import file_to_string, group_by_key_func, string_to_file
 
 # Hide 3rd party pretty-printing modules
 sys.modules['prettyprinter'] = {}
@@ -21,7 +22,8 @@ sys.modules['pprintpp'] = {}
 from snoop import formatting, install, spy
 from snoop.configuration import Config
 from snoop.pp_module import is_deep_arg
-from snoop.utils import truncate_string, truncate_list, needs_parentheses, NO_ASTTOKENS, NO_BIRDSEYE, PYPY
+from snoop.utils import (NO_ASTTOKENS, NO_BIRDSEYE, PYPY, needs_parentheses,
+                         truncate_list, truncate_string)
 
 formatting._get_filename = lambda _: "/path/to_file.py"
 
@@ -64,7 +66,7 @@ def sample_traceback():
 def assert_sample_output(module_name):
     module = import_module('tests.samples.' + module_name)
     old = sys.stderr
-    
+
     out = io.StringIO()
     sys.stderr = out
 
@@ -88,7 +90,7 @@ def assert_sample_output(module_name):
     normalised = normalised.replace(str(current_thread().ident), '123456789')
 
     result_filename = os.path.join(
-        tests_dir, 
+        tests_dir,
         'sample_results',
         PYPY * 'pypy' + '.'.join(sys.version.split('.')[:2]),
         module_name + '.txt',


### PR DESCRIPTION
was just running pylint runner
 - cleaned up white space
- tidied imports with isort
 - ensured tests still pass

There's a lot more that can be done once 2.7 stops getting supported.